### PR TITLE
migrate to Android X

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'com.android.application'
-
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "iammert.com.androidarchitecture"
         minSdkVersion 21
-        targetSdkVersion 25
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -30,35 +29,44 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
-    //support lib
-    compile rootProject.ext.supportLibAppCompat
-    compile rootProject.ext.supportLibDesign
 
-    compile rootProject.ext.archRuntime
-    compile rootProject.ext.archExtension
-    annotationProcessor rootProject.ext.archCompiler
 
-    compile rootProject.ext.roomRuntime
-    annotationProcessor rootProject.ext.roomCompiler
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.google.android.material:material:1.0.0'
+    implementation'androidx.lifecycle:lifecycle-runtime:2.1.0'
+    implementation'androidx.lifecycle:lifecycle-extensions:2.1.0'
 
-    compile rootProject.ext.okhttp
-    compile rootProject.ext.retrofit
-    compile rootProject.ext.gsonConverter
+    //noinspection LifecycleAnnotationProcessorWithJava8
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.1.0'
+    implementation'androidx.room:room-runtime:2.2.2'
+    annotationProcessor 'androidx.room:room-compiler:2.2.2'
+
 
     //dagger
-    annotationProcessor rootProject.ext.daggerCompiler
-    compile rootProject.ext.dagger
-    compile rootProject.ext.daggerAndroid
-    compile rootProject.ext.daggerAndroidSupport
-    annotationProcessor rootProject.ext.daggerAndroidProcessor
+    implementation "com.google.dagger:dagger:$daggerVersion"
+    annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
+    annotationProcessor "com.google.dagger:dagger-android-processor:$daggerVersion"
+    implementation "com.google.dagger:dagger-android-support:$daggerVersion"
 
-    //ui
-    compile rootProject.ext.picasso
+    implementation  "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation  "com.squareup.retrofit2:converter-gson:$gsonConverterVersion"
+    implementation  "com.squareup.okhttp3:okhttp:$okhttpVersion"
+
+    implementation  "com.squareup.picasso:picasso:$picassoVersion"
+
+
+
+
+
+
+
+
 
 }
+

--- a/app/src/androidTest/java/iammert/com/androidarchitecture/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/iammert/com/androidarchitecture/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package iammert.com.androidarchitecture;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/main/java/iammert/com/androidarchitecture/AAApp.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/AAApp.java
@@ -7,17 +7,18 @@ import javax.inject.Inject;
 
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
-import dagger.android.HasActivityInjector;
+import dagger.android.HasAndroidInjector;
 import iammert.com.androidarchitecture.di.DaggerAppComponent;
 
 /**
  * Created by mertsimsek on 20/05/2017.
+ * Updated by johnjeremih on 27/11/2019
  */
 
-public class AAApp extends Application implements HasActivityInjector {
+public class AAApp extends Application implements HasAndroidInjector {
 
     @Inject
-    DispatchingAndroidInjector<Activity> activityDispatchingInjector;
+    DispatchingAndroidInjector<Object> activityDispatchingInjector;
 
     @Override
     public void onCreate() {
@@ -32,8 +33,9 @@ public class AAApp extends Application implements HasActivityInjector {
                 .inject(this);
     }
 
+
     @Override
-    public AndroidInjector<Activity> activityInjector() {
-        return activityDispatchingInjector;
+    public AndroidInjector<Object> androidInjector() {
+        return  activityDispatchingInjector;
     }
 }

--- a/app/src/main/java/iammert/com/androidarchitecture/data/MovieRepository.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/data/MovieRepository.java
@@ -1,7 +1,7 @@
 package iammert.com.androidarchitecture.data;
 
-import android.arch.lifecycle.LiveData;
-import android.support.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/data/NetworkBoundResource.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/data/NetworkBoundResource.java
@@ -15,13 +15,13 @@
  */
 package iammert.com.androidarchitecture.data;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MediatorLiveData;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
 import android.os.AsyncTask;
-import android.support.annotation.MainThread;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.WorkerThread;
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import retrofit2.Call;
 import retrofit2.Callback;

--- a/app/src/main/java/iammert/com/androidarchitecture/data/Resource.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/data/Resource.java
@@ -16,8 +16,8 @@
 
 package iammert.com.androidarchitecture.data;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static iammert.com.androidarchitecture.data.Status.ERROR;
 import static iammert.com.androidarchitecture.data.Status.LOADING;

--- a/app/src/main/java/iammert/com/androidarchitecture/data/local/MovieDatabase.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/data/local/MovieDatabase.java
@@ -1,7 +1,7 @@
 package iammert.com.androidarchitecture.data.local;
 
-import android.arch.persistence.room.Database;
-import android.arch.persistence.room.RoomDatabase;
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
 
 import iammert.com.androidarchitecture.data.local.dao.MovieDao;
 import iammert.com.androidarchitecture.data.local.entity.MovieEntity;

--- a/app/src/main/java/iammert/com/androidarchitecture/data/local/dao/MovieDao.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/data/local/dao/MovieDao.java
@@ -1,10 +1,10 @@
 package iammert.com.androidarchitecture.data.local.dao;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
 
 import java.util.List;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/data/local/entity/MovieEntity.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/data/local/entity/MovieEntity.java
@@ -1,7 +1,7 @@
 package iammert.com.androidarchitecture.data.local.entity;
 
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/data/remote/RequestInterceptor.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/data/remote/RequestInterceptor.java
@@ -1,6 +1,6 @@
 package iammert.com.androidarchitecture.data.remote;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.IOException;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/databinding/ImageBindingAdapter.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/databinding/ImageBindingAdapter.java
@@ -1,7 +1,7 @@
 package iammert.com.androidarchitecture.databinding;
 
-import android.databinding.BindingAdapter;
-import android.support.v4.content.ContextCompat;
+import androidx.databinding.BindingAdapter;
+import androidx.core.content.ContextCompat;
 import android.widget.ImageView;
 
 import com.squareup.picasso.Picasso;
@@ -18,7 +18,7 @@ public final class ImageBindingAdapter {
     @BindingAdapter(value = "url")
     public static void loadImageUrl(ImageView view, String url) {
         if (url != null && !url.equals(""))
-            Picasso.with(view.getContext())
+            Picasso.get()
                     .load(ApiConstants.IMAGE_ENDPOINT_PREFIX + url)
                     .placeholder(R.drawable.placeholder)
                     .into(view);

--- a/app/src/main/java/iammert/com/androidarchitecture/databinding/ListBindingAdapter.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/databinding/ListBindingAdapter.java
@@ -1,7 +1,7 @@
 package iammert.com.androidarchitecture.databinding;
 
-import android.databinding.BindingAdapter;
-import android.support.v7.widget.RecyclerView;
+import androidx.databinding.BindingAdapter;
+import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
 
@@ -22,8 +22,5 @@ public final class ListBindingAdapter{
         if(resource == null || resource.data == null)
             return;
 
-        if(adapter instanceof BaseAdapter){
-            ((BaseAdapter)adapter).setData((List) resource.data);
-        }
     }
 }

--- a/app/src/main/java/iammert/com/androidarchitecture/di/AppModule.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/di/AppModule.java
@@ -1,8 +1,8 @@
 package iammert.com.androidarchitecture.di;
 
 import android.app.Application;
-import android.arch.lifecycle.ViewModelProvider;
-import android.arch.persistence.room.Room;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.room.Room;
 
 import java.util.concurrent.TimeUnit;
 
@@ -15,7 +15,6 @@ import iammert.com.androidarchitecture.data.local.dao.MovieDao;
 import iammert.com.androidarchitecture.data.remote.ApiConstants;
 import iammert.com.androidarchitecture.data.remote.MovieDBService;
 import iammert.com.androidarchitecture.data.remote.RequestInterceptor;
-import iammert.com.androidarchitecture.viewmodel.MovieViewModelFactory;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;

--- a/app/src/main/java/iammert/com/androidarchitecture/di/ViewModelKey.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/di/ViewModelKey.java
@@ -1,6 +1,6 @@
 package iammert.com.androidarchitecture.di;
 
-import android.arch.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModel;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/app/src/main/java/iammert/com/androidarchitecture/di/ViewModelModule.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/di/ViewModelModule.java
@@ -1,7 +1,7 @@
 package iammert.com.androidarchitecture.di;
 
-import android.arch.lifecycle.ViewModel;
-import android.arch.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
 
 import dagger.Binds;
 import dagger.Module;

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/BaseActivity.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/BaseActivity.java
@@ -1,25 +1,25 @@
 package iammert.com.androidarchitecture.ui;
 
-import android.databinding.DataBindingUtil;
-import android.databinding.ViewDataBinding;
+import androidx.databinding.DataBindingUtil;
+import androidx.databinding.ViewDataBinding;
 import android.os.Bundle;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.appcompat.app.AppCompatActivity;
 
 import javax.inject.Inject;
 
 import dagger.android.AndroidInjection;
-import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
-import dagger.android.support.HasSupportFragmentInjector;
+import dagger.android.support.DaggerAppCompatActivity;
 
 /**
  * Created by mertsimsek on 15/09/2017.
+ * Updated by johnjeremih on 26/11/2019
  */
 
-public abstract class BaseActivity<DB extends ViewDataBinding> extends AppCompatActivity implements HasSupportFragmentInjector {
+public abstract class BaseActivity<DB extends ViewDataBinding> extends DaggerAppCompatActivity {
 
     @Inject
     DispatchingAndroidInjector<Fragment> fragmentAndroidInjector;
@@ -36,8 +36,5 @@ public abstract class BaseActivity<DB extends ViewDataBinding> extends AppCompat
         dataBinding = DataBindingUtil.setContentView(this, getLayoutRes());
     }
 
-    @Override
-    public AndroidInjector<Fragment> supportFragmentInjector() {
-        return fragmentAndroidInjector;
-    }
+
 }

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/BaseAdapter.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/BaseAdapter.java
@@ -1,6 +1,6 @@
 package iammert.com.androidarchitecture.ui;
 
-import android.support.v7.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/BaseFragment.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/BaseFragment.java
@@ -1,16 +1,16 @@
 package iammert.com.androidarchitecture.ui;
 
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.LifecycleRegistryOwner;
-import android.arch.lifecycle.ViewModel;
-import android.arch.lifecycle.ViewModelProvider;
-import android.arch.lifecycle.ViewModelProviders;
-import android.databinding.DataBindingUtil;
-import android.databinding.ViewDataBinding;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.LifecycleRegistryOwner;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.databinding.DataBindingUtil;
+import androidx.databinding.ViewDataBinding;
 import android.os.Bundle;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/detail/MovieDetailActivity.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/detail/MovieDetailActivity.java
@@ -1,16 +1,17 @@
 package iammert.com.androidarchitecture.ui.detail;
 
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.LifecycleRegistryOwner;
-import android.arch.lifecycle.ViewModelProvider;
-import android.arch.lifecycle.ViewModelProviders;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.LifecycleRegistryOwner;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.Intent;
-import android.databinding.DataBindingUtil;
+import androidx.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v4.app.ActivityCompat;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import javax.inject.Inject;
@@ -23,7 +24,7 @@ import iammert.com.androidarchitecture.databinding.ActivityMovieDetailBinding;
  * Created by mertsimsek on 19/05/2017.
  */
 
-public class MovieDetailActivity extends AppCompatActivity implements LifecycleRegistryOwner {
+public class MovieDetailActivity extends AppCompatActivity implements LifecycleOwner {
 
     private static final String KEY_MOVIE_ID = "key_movie_id";
 

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/detail/MovieDetailViewModel.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/detail/MovieDetailViewModel.java
@@ -1,8 +1,8 @@
 package iammert.com.androidarchitecture.ui.detail;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
-import android.arch.lifecycle.ViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
 
 import javax.inject.Inject;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/main/MovieListAdapter.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/main/MovieListAdapter.java
@@ -1,7 +1,8 @@
 package iammert.com.androidarchitecture.ui.main;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/main/MovieListFragment.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/main/MovieListFragment.java
@@ -1,9 +1,10 @@
 package iammert.com.androidarchitecture.ui.main;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v4.app.ActivityOptionsCompat;
-import android.support.v7.widget.GridLayoutManager;
+import androidx.annotation.Nullable;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.recyclerview.widget.GridLayoutManager;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/main/MovieListViewModel.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/main/MovieListViewModel.java
@@ -1,7 +1,7 @@
 package iammert.com.androidarchitecture.ui.main;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.ViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
 
 import java.util.List;
 

--- a/app/src/main/java/iammert/com/androidarchitecture/ui/main/MoviesPagerAdapter.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/ui/main/MoviesPagerAdapter.java
@@ -1,8 +1,8 @@
 package iammert.com.androidarchitecture.ui.main;
 
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentStatePagerAdapter;
 
 /**
  * Created by mertsimsek on 20/05/2017.

--- a/app/src/main/java/iammert/com/androidarchitecture/viewmodel/MovieViewModelFactory.java
+++ b/app/src/main/java/iammert/com/androidarchitecture/viewmodel/MovieViewModelFactory.java
@@ -17,8 +17,8 @@
 
 package iammert.com.androidarchitecture.viewmodel;
 
-import android.arch.lifecycle.ViewModel;
-import android.arch.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
 
 import java.util.Map;
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,18 +2,18 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <android.support.design.widget.CoordinatorLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
 
-        <android.support.design.widget.AppBarLayout
+        <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/appbarLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
 
-            <android.support.design.widget.CollapsingToolbarLayout
+            <com.google.android.material.appbar.CollapsingToolbarLayout
                 android:id="@+id/collapsingToolbar"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -21,7 +21,7 @@
                 app:titleEnabled="false">
 
 
-                <android.support.v7.widget.Toolbar
+                <androidx.appcompat.widget.Toolbar
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="56dp"
@@ -39,12 +39,12 @@
                         android:textSize="@dimen/textSizeExtraLarge"
                         android:textStyle="bold"/>
 
-                </android.support.v7.widget.Toolbar>
+                </androidx.appcompat.widget.Toolbar>
 
 
-            </android.support.design.widget.CollapsingToolbarLayout>
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-            <android.support.design.widget.TabLayout
+            <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabs"
                 style="@style/MainTabStyle"
                 android:layout_width="match_parent"
@@ -53,15 +53,15 @@
                 android:layout_marginLeft="8dp"
                 android:layout_marginRight="8dp"/>
 
-        </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
 
-        <android.support.v4.view.ViewPager
+        <androidx.viewpager.widget.ViewPager
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-    </android.support.design.widget.CoordinatorLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
 </layout>
 

--- a/app/src/main/res/layout/activity_movie_detail.xml
+++ b/app/src/main/res/layout/activity_movie_detail.xml
@@ -21,13 +21,13 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <android.support.design.widget.AppBarLayout
+            <com.google.android.material.appbar.AppBarLayout
                 android:id="@+id/appbarLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
 
-                <android.support.v7.widget.Toolbar
+                <androidx.appcompat.widget.Toolbar
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="56dp"
@@ -47,9 +47,9 @@
                         android:textSize="@dimen/textSizeExtraLarge"
                         android:textStyle="bold" />
 
-                </android.support.v7.widget.Toolbar>
+                </androidx.appcompat.widget.Toolbar>
 
-            </android.support.design.widget.AppBarLayout>
+            </com.google.android.material.appbar.AppBarLayout>
 
 
             <RelativeLayout

--- a/app/src/main/res/layout/fragment_movie_list.xml
+++ b/app/src/main/res/layout/fragment_movie_list.xml
@@ -8,7 +8,7 @@
             type="iammert.com.androidarchitecture.data.Resource"/>
     </data>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,10 @@ buildscript {
     repositories {
         maven { url 'https://maven.google.com' }
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:3.5.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,6 +19,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url 'https://maven.google.com' }
+        google()
     }
 }
 
@@ -26,28 +28,14 @@ task clean(type: Delete) {
 }
 
 ext {
-    supportLibVersion = '25.3.1'
-    daggerVersion = '2.11'
-    retrofitVersion = '2.1.0'
-    gsonConverterVersion = '2.1.0'
-    okhttpVersion = '3.8.0'
-    picassoVersion = '2.5.2'
+    daggerVersion = '2.25.2'
+    retrofitVersion = '2.6.2'
+    gsonConverterVersion = '2.6.2'
+    okhttpVersion = '4.2.2'
+    picassoVersion = '2.71828'
     archVersion = '1.0.0-alpha1'
+    roomVersion = '2.2.1'
 
-    supportLibAppCompat = "com.android.support:appcompat-v7:$supportLibVersion"
-    supportLibDesign = "com.android.support:design:$supportLibVersion"
-    archRuntime = "android.arch.lifecycle:runtime:$archVersion"
-    archExtension = "android.arch.lifecycle:extensions:$archVersion"
-    archCompiler = "android.arch.lifecycle:compiler:$archVersion"
-    roomRuntime = "android.arch.persistence.room:runtime:$archVersion"
-    roomCompiler = "android.arch.persistence.room:compiler:$archVersion"
-    dagger = "com.google.dagger:dagger:$daggerVersion"
-    daggerCompiler = "com.google.dagger:dagger-compiler:$daggerVersion"
-    daggerAndroid = "com.google.dagger:dagger-android:$daggerVersion"
-    daggerAndroidSupport = "com.google.dagger:dagger-android-support:$daggerVersion"
-    daggerAndroidProcessor = "com.google.dagger:dagger-android-processor:$daggerVersion"
-    retrofit = "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    gsonConverter = "com.squareup.retrofit2:converter-gson:$gsonConverterVersion"
-    okhttp = "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    picasso = "com.squareup.picasso:picasso:$picassoVersion"
 }
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 18 17:31:31 EEST 2017
+#Mon Nov 04 12:34:50 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
When I opened this project the dependencies were outdated. Proceed to update them and migrate to Android X.
- This project was utilizing compile, so I changed it to implementation.

- LifecycleRegistryOwner is now deprecated. Now we use LifecycleOwner.

- The implementation of HasSupportFragmentInjector is no longer necessary. Now,  we only have to extend DaggerAppCompatActivity instead of AppCompatActivity.

- Picasso no longer need Picasso.with(view.getContext). We now use Picasso.get()

- The HasAndroidInjector implementation  no longer need Activity, now we use Object